### PR TITLE
Temporary fix for SRAT parsing

### DIFF
--- a/loader/src/acpi.c
+++ b/loader/src/acpi.c
@@ -167,10 +167,24 @@ static void acpi_parse_srat(acpi_srat_t *srat)
         switch (entry->type) {
         case ACPI_SRAT_TYPE_LAPIC:
             acpi_parse_srat_lapic((acpi_srat_lapic_t *) entry);
+
+            length_remaining -= sizeof(acpi_srat_lapic_t);
+            entry = (acpi_srat_entry_t *)((char *)entry + sizeof(acpi_srat_lapic_t));
+
+            break;
+
+        case ACPI_SRAT_TYPE_MEMORY:
+            // No clue what to do with this.
+
+            length_remaining -= sizeof(acpi_srat_memory_t);
+            entry = (acpi_srat_entry_t *)((char *)entry + sizeof(acpi_srat_memory_t));
             break;
 
         case ACPI_SRAT_TYPE_X2LAPIC:
             acpi_parse_srat_x2lapic((acpi_srat_x2lapic_t *) entry);
+
+            length_remaining -= sizeof(acpi_srat_x2lapic_t);
+            entry = (acpi_srat_entry_t *)((char *)entry + sizeof(acpi_srat_x2lapic_t));
             break;
         }
     }


### PR DESCRIPTION
The code was incomplete - it was looping forever when the table was provided.

I admit I have no clue what's in those tables but this fix was imperative. Without it, Hydrogen won't work in Hyper-V or VMWare. (tried both)

I'd be glad if you could make sense of whatever is in the memory table.

This minor issue aside, your bootloader rocks.
